### PR TITLE
docs: add official Discord community link to README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ mycli command --param value     # Consistent parameter handling
 
 ### **💬 Get Involved**
 
+- **[Discord Community](https://discord.gg/DHthnuhWBm)** - Join our Discord server for real-time discussions
 - **[GitHub Discussions](https://github.com/nrranjithnr/open-cli-specification/discussions)** - Spec evolution and community discussion
 - **[GitHub Issues](https://github.com/nrranjithnr/open-cli-specification/issues)** - Bug reports, features, and feedback
 

--- a/src/components/sections/Home.tsx
+++ b/src/components/sections/Home.tsx
@@ -303,6 +303,15 @@ commands:
                   GitHub Repository
                 </a>
                 <a
+                  href="https://discord.gg/DHthnuhWBm"
+                  className="home__cta-link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span className="home__cta-icon">💬</span>
+                  Join Discord
+                </a>
+                <a
                   href="#"
                   className="home__cta-link"
                   onClick={e => {


### PR DESCRIPTION
### Summary
This PR adds the official **OpenCLISpec Discord community** link to the README and website to help contributors and users connect, discuss ideas, and collaborate more easily.

### Changes
- 📝 Updated `README.md` with a Discord badge and invite link  
- 🌐 Added Discord link to the website (footer / community section)  

### Related Issue
Closes [#9](https://github.com/nrranjithnr/open-cli-specification/issues/9)
